### PR TITLE
Update sceneMan.lua to 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,29 @@ See the [Freezing](https://github.com/KINGTUT10101/SceneMan/wiki/Freezing) page 
 
 ### Changelog:
 
-*   Version 1.1:
+*   Version 1.1.0:
     *   Added stack freezing.
     *   The stack will automatically freeze while using the event and clearStack methods.
-*   Version 1.2:
+*   Version 1.2.0:
     *   Added stack saving.
     *   Stacks can now be saved and restored using unique IDs assigned to each saved stack.
-*   Version 1.3:
+*   Version 1.3.0:
     *   Added stack locking.
     *   Stacks can now be locked up to a specified level. Any scenes at and below the specified level will be skipped during an event trigger. This can be used to easily transition to a new scene and back. Simply lock the stack, push the new scene, run its code, pop the new scene, and unlock the stack.
-*   Version 1.4:
+*   Version 1.4.0:
     *   Added a function for getting the current lock level value.
     *   Added a function for clearing the unlocked portion of the stack, aka all the scenes above the current lock level value.
 *   Version 1.4.1:
     *   A scene's load method will no longer automatically pass the sceneMan library as the first argument.
     *   Fixed a bug/oversight where the varargs were not passed to a scene's delete method.
     *   Added EmmyLua style comments to the library.
+*   Version 1.4.2:
+    *   Added assertions to sceneMan:newScene to ensure that scene names are strings and that scenes are not accidentally redefined.
+    *   Fixed some comments and documentation in the code.
+    *   Added sceneMan:getSceneAt method for getting the name of a scene at a specific index of the stack.
+    *   Added sceneMan:getSceneIndex method for getting the index of a specific scene in the stack.
+    *   Fixed a bug with the sceneMan:insert method that inserted the scene's name instead of its table.
+    *   Updated sceneMan:remove method so users can specify what scene they'd like to remove using either their index or their name.
 
 ### Documentation:
 
@@ -53,77 +60,88 @@ sceneMan.saved = {} -- Stores saved stacks so they can be restored later
 sceneMan.buffer = {} -- Stores the scene stack when the original scene stack is disabled
 sceneMan.frozen = false -- If true, the buffer will be used instead of the original stack
 lockLevel = 0 -- They highest level of the stack that is locked
-sceneMan.version = "1.4.1" -- The used version of Scene Man
+sceneMan.version = "1.4.2" -- The used version of Scene Man
 ```
 
 #### Methods:
 
 ```lua
---- Adds a new scene to Scene Man and initializes it via its load method.
--- This will call the scene's "load" method
--- @param name (string) The name of the new scene. This will be used later to push, insert, and remove this scene from the stack
--- @param scene (table) A table containing the scene's attributes and callback functions
--- @param ... (varargs) A series of values that will be passed to the scene's "load" callback
+--- Adds a new scene and initializes it via its `load` method.
+---@param name string Name of the new scene (used for later operations like push/remove).
+---@param scene table Table containing attributes and callback functions of the scene.
+---@vararg any Values passed to the `load` callback function of this scene.
 sceneMan:newScene (name, scene, ...)
 
---- Removes a scene from Scene Man and calls its delete method.
--- This will call the scene's "delete" method
--- If you try to push or insert a deleted scene, Scene Man will throw an error!
--- @param name (string) The name of the scene that should be deleted
--- @param ... (varargs) A series of values that will be passed to the scene's "delete" callback
+--- Deletes a registered scene and calls its `delete` method. Deleted scenes cannot be pushed or inserted again.
+---@param name string Name of the scene to delete.
+---@vararg any Values passed to the `delete` callback function of this scene.
 sceneMan:deleteScene (name)
 
---- Returns the current size of the stack.
--- @return (int) The size of the stack
+--- Gets the current size of the stack.
+---@return integer size The size of the stack (number of scenes).
 sceneMan:getStackSize ()
 
---- Gives the name of the current scene. It will return nil is there are no scenes on the stack.
--- @return (string) The name of the scene at the top of the stack
+--- Gets the name of the current topmost scene on the stack.
+--- This will ignore the frozen buffer.
+---@return string|nil sceneName Name of topmost scene or nil if the stack is empty.
 sceneMan:getCurrentScene ()
 
---- Adds a scene from the scenes table onto the stack.
--- This will call the scene's "whenAdded" method
--- Scenes at the top of the stack will have their functions called last
--- @raise When the given scene name isn't registered inside Scene Man
--- @param name (string) The name of the scene to add to the top of the stack
--- @param ... (varargs) A list of values that will be passed to the event's "whenAdded" callback function
+--- Gets the name of the scene at the provided index in the stack.
+--- This will ignore the frozen buffer.
+---@param index integer The index of the scene.
+---@return string|nil sceneName Name of topmost scene or nil if the stack is empty.
+sceneMan:getSceneAt (index)
+
+--- Gets the index of a scene in the stack matching the provided name.
+--- This will ignore the frozen buffer.
+--- If the scene is present multiple times in the stack, this function will only return the index of the first scene found, starting from the top of the stack.
+---@param sceneName string The name of the desired scene.
+---@return integer|nil index Name of the scene at the given index or nil if the stack is empty.
+sceneMan:getSceneIndex (sceneName)
+
+--- Pushes a registered scene onto the top of the stack and calls its `whenAdded` method.
+--- Scenes at the top of the stack will have their functions called last
+---@param name string Name of registered scene to push onto stack.
+---@vararg any Values passed to `whenAdded` callback function of this scene.
 sceneMan:push (name, ...)
 
 --- Pops a scene off of the stack.
--- This will call the topmost scene's "whenRemoved" method
--- @param ... (varargs) A list of values that will be passed to the event's "whenRemoved" callback function
+--- This will call the topmost scene's `whenRemoved` method.
+---@vararg any Values passed to the `whenRemoved` callback function of this scene.
 sceneMan:pop (...)
 
 --- Adds a scene to the stack at a given index.
--- This will call the scene's "whenAdded" method
--- @raise When the given scene name isn't registered inside Scene Man
--- @param name (string) The name of the scene to add to the top of the stack
--- @param index (int) The position within the stack that the scene should be inserted at
--- @param ... (varargs) A list of values that will be passed to the event's "whenAdded" callback function
--- @return (bool) True if the operation was successful
+--- This will call the scene's `whenAdded` method.
+---@param name string The name of the scene to add to the stack.
+---@param index integer The position within the stack that the scene should be inserted at.
+---@vararg any Values passed to the `whenAdded` callback function of this scene.
+---@return boolean success True if the scene was successfully inserted, false otherwise.
 sceneMan:insert (name, index, ...)
 
 --- Removes a scene from the stack at a certain index.
--- This will call the scene's "whenRemoved" method
--- @param index (int) The position within the stack that the scene should be removed at
--- @param ... (varargs) A list of values that will be passed to the event's "whenRemoved" callback function
--- @return (bool) True if the operation was successful
-sceneMan:remove (index, ...)
+--- This will call the scene's `whenRemoved` method.
+--- If a scene is present multiple times in the stack and a name is provided for the key, the first scene found starting at the top of the stack will be removed.
+---@param key integer|string The position within the stack or the name of a scene that should be removed from the stack.
+---@vararg any Values passed to the `whenRemoved` callback function of this scene.
+---@return boolean success True if a scene was removed, false if the operation failed or if the scene with the provided name was not found.
+sceneMan:remove (key, ...)
 
---- Removes all scenes from the stack.
--- This will call all the scenes' "whenRemoved" methods, starting from the topmost scene
--- @param ... (varargs) A list of values that will be passed to the event's "whenRemoved" callback function
+--- Removes all scenes from the stack, starting at the top.
+--- This will call all the scenes' `whenRemoved` methods, starting from the topmost scene.
+--- This will automatically freeze the stack until all scenes have been iterated over.
+---@vararg any Values passed to the `whenRemoved` callback function of this scene.
 sceneMan:clearStack (...)
 
 --- Removes all scenes from the unlocked portion of the stack, starting at the top.
--- This will call all the scenes' "whenRemoved" methods, starting from the topmost scene
--- This will automatically freeze the stack until all scenes have been iterated over
--- @param ... (varargs) A list of values that will be passed to the event's "whenRemoved" callback function
+--- This will call all the scenes' `whenRemoved` methods, starting from the topmost scene.
+--- This will automatically freeze the stack until all scenes have been iterated over.
+---@vararg any Values passed to the `whenRemoved` callback function of this scene.
 sceneMan:clearUnlockedStack (...)
 
 --- Fires an event callback for all scenes on the stack.
--- @param eventName (string) The name of the event
--- @param ... (varargs) A series of values that will be passed to the scenes' event callbacks
+--- This will automatically freeze the stack until all scenes have been iterated over.
+---@param eventName string The name of the event.
+---@vararg any Values passed to the scenes' event callbacks.
 sceneMan:event (eventName, ...)
 
 --- Redirects stack-altering operations into the buffer instead.
@@ -132,35 +150,34 @@ sceneMan:freeze ()
 --- Copies the changes from the buffer back into the original stack.
 sceneMan:unfreeze ()
 
---- Locks the stack up until the specified level.
--- Locked scenes will have their event callbacks skipped, except for their "whenAdded", "whenRemoved", or "deleted" methods
--- The bottommost item of the stack is at level 1
--- @param level (int) The level that the stack should be locked up to
+--- Locks the stack up to a specified level.
+--- Locked scenes skip their event callbacks except "whenAdded", "whenRemoved", or "deleted".
+---@param level integer The level to lock up to (bottommost item is at level 1).
 sceneMan:lock (level)
 
---- Unlocks the stack, which will allow all scenes to execute their event callbacks again.
+--- Unlocks all levels in the stack, allowing all scenes to execute their event callbacks again.
 sceneMan:unlock ()
 
---- Gets the current lock level.
--- @return (int) The current lock level
+--- Gets the current lock level of the stack.
+---@return integer level The current lock level.
 sceneMan:getLockLevel ()
 
---- Saves the current state of the stack so it can be restored later.
--- This will save the frozen buffer if the stack is frozen
--- This will not modify the current stack in any way
--- @param id (string) A unique ID that will be used to identify the saved stack. It will override anything currently stored at that ID
+--- Saves the current contents of the stack so it can be restored later.
+--- This will save the frozen buffer if the stack is frozen.
+--- This will not modify the current stack in any way.
+---@param id string A unique ID to identify the saved stack. Overrides any existing entry at this ID.
 sceneMan:saveStack (id)
 
---- Loads a stack from the saved table.
--- This will call the loaded scenes' "whenAdded" methods
--- @param id (string) A unique ID that identifies the stack that should be restored
--- @param ... (varargs) A list of values that will be passed to the event's "whenAdded" callback function
--- @return (bool) True if the stored stack at the given ID exists and if the current stack is empty, otherwise false
+--- Restores a saved stack from storage.
+--- This will call the loaded scenes' "whenAdded" methods.
+---@param id string A unique ID identifying the stack to restore.
+---@vararg any Values passed to the "whenAdded" callback function of scenes.
+---@return boolean success True if restoration succeeded (stack exists and current stack is empty), false otherwise.
 sceneMan:restoreStack (id, ...)
 
---- Removes a saved stack permanently.
--- This will not delete the scenes in the stack
--- This will not affect the current stack, even if it was restored using the to-be-deleted stack
--- @param id (string) A unique ID that identifies the stack that should be deleted
+--- Deletes a saved stack permanently.
+--- Does not affect scenes in the current stack, even if it was restored using the to-be-deleted stack.
+--- This will not *delete* the scenes in the stack.
+---@param id string A unique ID identifying the saved stack to delete.
 sceneMan:deleteStack (id)
 ```

--- a/sceneMan.lua
+++ b/sceneMan.lua
@@ -127,6 +127,9 @@ end
 ---@param scene table Table containing attributes and callback functions of the scene.
 ---@vararg any Values passed to the `load` callback function of this scene.
 function sceneMan:newScene (name, scene, ...)
+    assert (type (name) == "string", "Provided scene name is not a string")
+    assert (self.scenes[name] == nil, "A scene with the name '" .. name .. "' has already been defined")
+
     self.scenes[name] = scene
     self.scenes[name].name = name
     if self.scenes[name].load ~= nil then
@@ -152,10 +155,32 @@ function sceneMan:getStackSize ()
     return #self.stack
 end
 
---- Gets the name of the current topmost scene on the stack. Returns nil if no scenes exist in it (ignores frozen buffer).
----@return string|nil sceneName Name of topmost scene or nil if empty.
+--- Gets the name of the current topmost scene on the stack.
+--- This will ignore the frozen buffer.
+---@return string|nil sceneName Name of topmost scene or nil if the stack is empty.
 function sceneMan:getCurrentScene ()
     return (#self.stack >= 1) and self.stack[#self.stack].name or nil
+end
+
+--- Gets the name of the scene at the provided index in the stack.
+--- This will ignore the frozen buffer.
+---@param index integer The index of the scene.
+---@return string|nil sceneName Name of topmost scene or nil if the stack is empty.
+function sceneMan:getSceneAt (index)
+    return self.stack[index].name
+end
+
+--- Gets the index of a scene in the stack matching the provided name.
+--- This will ignore the frozen buffer.
+--- If the scene is present multiple times in the stack, this function will only return the index of the first scene found, starting from the top of the stack.
+---@param sceneName string The name of the desired scene.
+---@return integer|nil index Name of the scene at the given index or nil if the stack is empty.
+function sceneMan:getSceneIndex (sceneName)
+    for i = #self.stack, 1, -1 do
+        if self.stack[i].name == sceneName then
+            return i
+        end
+    end
 end
 
 --- Pushes a registered scene onto the top of the stack and calls its `whenAdded` method.
@@ -195,7 +220,7 @@ end
 ---@param name string The name of the scene to add to the stack.
 ---@param index integer The position within the stack that the scene should be inserted at.
 ---@vararg any Values passed to the `whenAdded` callback function of this scene.
----@return boolean success True if the operation was successful, false otherwise.
+---@return boolean success True if the scene was successfully inserted, false otherwise.
 function sceneMan:insert (name, index, ...)
     local stack = getStack ()
     
@@ -204,10 +229,11 @@ function sceneMan:insert (name, index, ...)
     end
     
     if index >= 1 and index <= #stack then
-        table.insert (stack, index, name)
+        table.insert (stack, index, self.scenes[name])
         if self.scenes[name].whenAdded ~= nil then
             self.scenes[name]:whenAdded (...)
         end
+
         return true
     end
     return false
@@ -215,19 +241,37 @@ end
 
 --- Removes a scene from the stack at a certain index.
 --- This will call the scene's `whenRemoved` method.
----@param index integer The position within the stack that the scene should be removed at.
+--- If a scene is present multiple times in the stack and a name is provided for the key, the first scene found starting at the top of the stack will be removed.
+---@param key integer|string The position within the stack or the name of a scene that should be removed from the stack.
 ---@vararg any Values passed to the `whenRemoved` callback function of this scene.
----@return boolean success True if the operation was successful, false otherwise.
-function sceneMan:remove (index, ...)
+---@return boolean success True if a scene was removed, false if the operation failed or if the scene with the provided name was not found.
+function sceneMan:remove (key, ...)
     local stack = getStack ()
-    
-    if index >= 1 and index <= #stack then
-        local temp = stack[index]
-        table.remove (stack, index)
-        if temp.whenRemoved ~= nil then
-            temp:whenRemoved (...)
+    local index
+
+    if type (key) == "number" then
+        index = key
+
+        if index < 1 and index > #stack then
+            return false
         end
+    elseif type (key) == "string" then
+        index = self:getSceneIndex (key)
+
+        if index == nil then
+            return false
+        end
+    else
+        assert ("Provided scene key is not a string or integer index")
     end
+    
+    local temp = stack[index]
+    table.remove (stack, index)
+    if temp.whenRemoved ~= nil then
+        temp:whenRemoved (...)
+    end
+
+    return true
 end
 
 --- Removes all scenes from the stack, starting at the top.

--- a/sceneMan.lua
+++ b/sceneMan.lua
@@ -51,11 +51,6 @@ function sceneMan:unfreeze ()
 end
 
 --- Saves the current contents of the stack so it can be restored later.
--- This will save the frozen buffer if the stack is frozen
--- This will not modify the current stack in any way
--- @param id (string) A unique ID that will be used to identify the saved stack. It will override anything currently stored at that ID
-
---- Saves the current contents of the stack so it can be restored later.
 --- This will save the frozen buffer if the stack is frozen.
 --- This will not modify the current stack in any way.
 ---@param id string A unique ID to identify the saved stack. Overrides any existing entry at this ID.
@@ -69,12 +64,6 @@ function sceneMan:saveStack (id)
 
     self.saved[id] = savedStack
 end
-
---- Loads a stack from the saved table.
--- This will call the loaded scenes' "whenAdded" methods
--- @param id (string) A unique ID that identifies the stack that should be restored
--- @param ... (varargs) A list of values that will be passed to the event's "whenAdded" callback function
--- @return (bool) True if the stored stack at the given ID exists and if the current stack is empty, otherwise false
 
 --- Restores a saved stack from storage.
 --- This will call the loaded scenes' "whenAdded" methods.

--- a/sceneMan.lua
+++ b/sceneMan.lua
@@ -15,7 +15,7 @@ local sceneMan = {
     ---@type integer The highest level of the stack that is locked.
     lockLevel = 0,
     ---@type string The version of Scene Manager being used.
-    version = "1.4.1",
+    version = "1.4.2",
 }
 
 --- Returns either the buffer or the stack based on the value of `sceneMan.frozen`.


### PR DESCRIPTION
- Add assertions to sceneMan:newScene to ensure that scene names are strings and that scenes are not accidentally redefined.
- Fix some comments and documentation in the code.
- Add sceneMan:getSceneAt method for getting the name of a scene at a specific index of the stack.
- Add sceneMan:getSceneIndex method for getting the index of a specific scene in the stack.
- Fix a bug with the sceneMan:insert method that inserted the scene's name instead of its table.
- Updated sceneMan:remove method so users can specify what scene they'd like to remove using either their index or their name.